### PR TITLE
fix: set required datasource and remote URLs in vm-agent Helm values using monitoring domain

### DIFF
--- a/helm/vmetrics/agent.yaml.liquid
+++ b/helm/vmetrics/agent.yaml.liquid
@@ -1,6 +1,17 @@
 vmagent:
   enabled: true
 
+  spec:
+    datasource:
+      url: "http://monitoring.drafttests.click:8428"
+    remoteWrite:
+      url: "http://monitoring.drafttests.click:8429"
+    remoteRead:
+      url: "http://monitoring.drafttests.click:8429"
+
+    externalLabels:
+      cluster: {{ cluster.handle }}
+
   additionalRemoteWrites:
   - url: '{{ contexts["plrl/cloud/observability"].vmetrics.url }}'
     basicAuth:
@@ -10,10 +21,6 @@ vmagent:
       password:
         name: vm-auth
         key: password
-
-  spec:
-    externalLabels:
-      cluster: {{ cluster.handle }}
 
 prometheus-operator-crds:
   enabled: true


### PR DESCRIPTION
### Summary

The issue with the failing `vm-agent` service deployment is due to missing required configuration values for datasource and remote URLs in the VictoriaMetrics Helm chart `agent.yaml.liquid`. This caused validation errors preventing the custom resource from deploying properly.

This PR adds the required `spec.datasource.url`, `spec.remoteWrite.url`, and `spec.remoteRead.url` fields in the `vmagent` spec with the appropriate URLs using the existing DNS domain `monitoring.drafttests.click` and respective ports. 

### Changes Made
- Added `spec.datasource.url` pointing to `http://monitoring.drafttests.click:8428`
- Added `spec.remoteWrite.url` and `spec.remoteRead.url` pointing to `http://monitoring.drafttests.click:8429`

### Rationale
- These URLs are required by the VictoriaMetrics operator custom resource to deploy valid pods.
- Using the established DNS domain ensures connectivity to VictoriaMetrics via the cluster load balancer.
- Fixes the invalid resource error and enables the `vm-agent` pods to run and scrape metrics.

Please apply and sync the deployment to resolve the current sync and connectivity failures.